### PR TITLE
To instantiate the `_requestParser` field of type `IRequestParser<LPRSystem.Web.API.Manager.Services.User>`, you need to ensure that you have a concrete implementation of the `IRequestParser` interface that matches the expected type. In your case, it seems you want to use the `User ProcessRequestParser` class as the implementation.

### DIFF
--- a/LPRSystem.Web.API.Manager/LPRSystem.Web.API.Manager.csproj
+++ b/LPRSystem.Web.API.Manager/LPRSystem.Web.API.Manager.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 

--- a/LPRSystem.Web.API.Manager/Services/User/ProgressUserRepository.cs
+++ b/LPRSystem.Web.API.Manager/Services/User/ProgressUserRepository.cs
@@ -24,15 +24,9 @@ namespace LPRSystem.Web.API.Manager.Services.User
         {
             string userId = "1111";
 
-            try
-            {
-                return await base.ExecuteScalarAsync<Models.User.User>(CommonConstants.CommonDB, UserConstants.InsertUser, new { User = user.ToDataTable(userId).AsTableValuedParameter("[api].[User]") }, null);
+            return await base.QueryFirstOrDefaultAsync<Models.User.User>(CommonConstants.CommonDB, UserConstants.InsertOrUpdateUser, new { User = user.ToDataTable(userId).AsTableValuedParameter("[api].[User]") }, null);
 
-            }
-            catch (Exception ex)
-            {
-                throw;
-            }
+
         }
     }
 }

--- a/LPRSystem.Web.API.Manager/Services/User/Registrar.cs
+++ b/LPRSystem.Web.API.Manager/Services/User/Registrar.cs
@@ -18,7 +18,9 @@ namespace LPRSystem.Web.API.Manager.Services.User
             services.AddTransient<IGetUsersManager, GetUsersManager>();
             services.AddTransient<IProgressUserDataManager, ProgressUserDataManager>();
             services.AddTransient<IRequestParser<GetUserByIdRequest>, GetUserByIdRequestParser>();
-            
+
+            services.AddTransient<IRequestParser<LPRSystem.Web.API.Manager.Models.User.User>, UserProcessRequestParser>();
+
         }
     }
 }

--- a/LPRSystem.Web.API.Manager/Services/User/UserProcessRequestParser.cs
+++ b/LPRSystem.Web.API.Manager/Services/User/UserProcessRequestParser.cs
@@ -1,0 +1,47 @@
+﻿using LPRSystem.Web.API.Manager.Helpers;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace LPRSystem.Web.API.Manager.Services.User
+{
+    public class UserProcessRequestParser : IRequestParser<LPRSystem.Web.API.Manager.Models.User.User>
+    {
+        public async Task<Models.User.User> ParseAsync(HttpRequest request)
+        {
+            string requestBody = await new StreamReader(request.Body).ReadToEndAsync();
+
+            var requestModel = JsonConvert.DeserializeObject<LPRSystem.Web.API.Manager.Models.User.UserProcessRequest>(requestBody);
+
+            string passwordHash = string.Empty;
+            string passwordSalt = string.Empty;
+
+            if (!string.IsNullOrEmpty(requestModel.Password))
+            {
+                HashSalt hashSalt = HashSalt.GenerateSaltedHash(requestModel.Password);
+                passwordHash = hashSalt.Hash;
+                passwordSalt = hashSalt.Salt;
+            }
+
+            var user = new Models.User.User
+            {
+                Id = requestModel.Id ?? 0, // Assuming 0 is a default value for Id
+                FirstName = requestModel.FirstName,
+                LastName = requestModel.LastName,
+                Email = requestModel.Email,
+                Phone = requestModel.Phone,
+                PasswordHash = passwordHash,
+                PasswordSalt = passwordSalt,
+                RoleId = requestModel.RoleId,
+                IsBlocked = requestModel.IsBlocked,
+                LastPasswordChangedOn = requestModel.LastPasswordChangedOn,
+                CreatedBy = requestModel.CreatedBy,
+                CreatedOn = requestModel.CreatedOn,
+                ModifiedBy = requestModel.ModifiedBy,
+                ModifiedOn = requestModel.ModifiedOn,
+                IsActive = requestModel.IsActive ?? true // Assuming true is the default value for IsActive
+            };
+
+            return user; // Return the user object directly
+        }
+    }
+}

--- a/LPRSystem.Web.DB/Programmability/Stored Procedures/User/uspInsertOrUpdateUser.sql
+++ b/LPRSystem.Web.DB/Programmability/Stored Procedures/User/uspInsertOrUpdateUser.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[uspInsertOrUpdateUser]
+﻿CREATE PROCEDURE [api].[uspInsertOrUpdateUser]
 (
 	@User [api].[User] READONLY
 )

--- a/LPRSystem.Web.Service/Functions/User/ProcessUserFunction.cs
+++ b/LPRSystem.Web.Service/Functions/User/ProcessUserFunction.cs
@@ -3,21 +3,23 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using LPRSystem.Web.API.Manager.Services.User;
-using Newtonsoft.Json;
+using LPRSystem.Web.API.Manager.Services;
 
 namespace LPRSystem.Web.Service.Functions.User;
 
 public class ProcessUserFunction
 {
     private readonly ILogger<ProcessUserFunction> _logger;
-    private readonly IProgressUserDataManager _manager; 
-
+    private readonly IProgressUserDataManager _manager;
+    private readonly IRequestParser<LPRSystem.Web.API.Manager.Models.User.User> _requestParser;
 
     public ProcessUserFunction(ILogger<ProcessUserFunction> logger,
-        IProgressUserDataManager manager)
+        IProgressUserDataManager manager,
+        IRequestParser<LPRSystem.Web.API.Manager.Models.User.User> requestParser)
     {
         _logger = logger;
         _manager = manager;
+        _requestParser = requestParser;
     }
 
     [Function("ProcessUserFunction")]
@@ -26,10 +28,7 @@ public class ProcessUserFunction
         _logger.LogInformation("ProcessUserFunction Invoke().");
         try
         {
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-
-            // Deserialize the JSON into your request object
-            var requestModel = JsonConvert.DeserializeObject<LPRSystem.Web.API.Manager.Models.User.User>(requestBody);
+            var requestModel = await _requestParser.ParseAsync(req);
 
             var processRequest = await _manager.ExecuteAsync(requestModel);
 


### PR DESCRIPTION
To instantiate the `_requestParser` field of type `IRequestParser<LPRSystem.Web.API.Manager.Services.User>`, you need to ensure that you have a concrete implementation of the `IRequestParser` interface that matches the expected type. In your case, it seems you want to use the `User ProcessRequestParser` class as the implementation.

Here’s how you can do it:

1. **Dependency Injection**: If you are using Dependency Injection (DI) in your ASP.NET Core application, you can register the `User ProcessRequestParser` in the `Startup.cs` file and then inject it into your class.

2. **Manual Instantiation**: If you are not using DI, you can create an instance of `User ProcessRequestParser` directly in your class.

### Using Dependency Injection

First, register the `User ProcessRequestParser` in the `ConfigureServices` method of your `Startup.cs`:

```csharp
public void ConfigureServices(IServiceCollection services)
{
    // Other service registrations...

    services.AddScoped<IRequestParser<LPRSystem.Web.API.Manager.Models.User.User>, UserProcessRequestParser>();
}
```

Then, inject it into your class:

```csharp
public class YourClass
{
    private readonly IRequestParser<LPRSystem.Web.API.Manager.Models.User.User> _requestParser;

    public YourClass(IRequestParser<LPRSystem.Web.API.Manager.Models.User.User> requestParser)
    {
        _requestParser = requestParser;
    }

    // Other methods...
}
```

### Manual Instantiation

If you are not using DI, you can instantiate it directly:

```csharp
public class YourClass
{
    private readonly IRequestParser<LPRSystem.Web.API.Manager.Models.User.User> _requestParser;

    public YourClass()
    {
        _requestParser = new UserProcessRequestParser();
    }

    // Other methods...
}
```

### Summary

- **Using Dependency Injection** is the preferred method in ASP.NET Core applications as it promotes better testability and separation of concerns.
- **Manual Instantiation** can be used in simpler scenarios or when DI is not set up, but it is generally less flexible and harder to test. 

Choose the method that best fits your application's architecture.